### PR TITLE
Update reminder email to include unique link

### DIFF
--- a/src/pages/admin/surveys/campaigns/[id]/components/OverviewTab/PendingRespondents.tsx
+++ b/src/pages/admin/surveys/campaigns/[id]/components/OverviewTab/PendingRespondents.tsx
@@ -98,6 +98,7 @@ export function PendingRespondents({ campaignId, instanceId }: Props) {
           dueDate: assignment.due_date,
           recipientEmail: respondent.email,
           recipientName: `${respondent.first_name || ''} ${respondent.last_name || ''}`.trim() || 'Participant',
+          publicAccessToken: respondent.public_access_token,
         },
       });
 

--- a/supabase/functions/send-survey-reminder/index.ts
+++ b/supabase/functions/send-survey-reminder/index.ts
@@ -17,6 +17,7 @@ interface ReminderRequest {
   dueDate: string | null;
   recipientEmail: string;
   recipientName: string;
+  publicAccessToken: string;
 }
 
 const handler = async (req: Request): Promise<Response> => {
@@ -85,6 +86,9 @@ const handler = async (req: Request): Promise<Response> => {
       }
     }
 
+    // Generate the public access URL
+    const publicAccessUrl = `${SUPABASE_URL.replace('.supabase.co', '')}/public/survey/${reminderRequest.publicAccessToken}`;
+
     // Send reminder email using Resend
     console.log("Sending email via Resend...");
     const dueDateText = reminderRequest.dueDate 
@@ -106,7 +110,10 @@ const handler = async (req: Request): Promise<Response> => {
             <h2>Hello ${reminderRequest.recipientName},</h2>
             <p>This is a friendly reminder that you have a pending survey to complete: <strong>${reminderRequest.surveyName}</strong></p>
             <p>${dueDateText}</p>
-            <p>Please log in to the survey system to complete your response.</p>
+            <p>You can complete the survey by clicking the link below:</p>
+            <p><a href="${publicAccessUrl}" style="display: inline-block; background-color: #2563eb; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px;">Complete Survey</a></p>
+            <p style="color: #666; font-size: 14px;">If the button doesn't work, you can copy and paste this link into your browser:</p>
+            <p style="color: #666; font-size: 14px;">${publicAccessUrl}</p>
             <p>Thank you for your participation!</p>
           </div>
         `,


### PR DESCRIPTION
The reminder email sent to pending respondents will now include a unique link that allows recipients to access the survey without requiring a login. This change enhances user experience by simplifying access to the survey. [skip gpt_engineer]